### PR TITLE
PR-11: Fix logs not in realtime

### DIFF
--- a/lib/helpers/aruba_logger.rb
+++ b/lib/helpers/aruba_logger.rb
@@ -45,16 +45,19 @@ module ArubaLogger
     def debug(message)
       @last_log = message
       @logger.debug(c(:blue, message)) if @log_level >= 3
+      STDOUT.flush
     end
 
     def error(message)
       @last_log = message
       @logger.error(c(:red, message))
+      STDOUT.flush
     end
 
     def info(message)
       @last_log = message
       @logger.info(c(:green, message)) if @log_level >= 2
+      STDOUT.flush
     end
   end
 end


### PR DESCRIPTION
* The logs were showing only when the process exited or crashed. This was solved by flushing the STDOUT for every log.