### PR TITLE
PR-23: BugFix - The associated clients got associated with turned-off access points.

### DIFF
--- a/lib/api/aruba_client.rb
+++ b/lib/api/aruba_client.rb
@@ -211,6 +211,8 @@ module ArubaREST
       closest_distance = nil
       data[:aps].each do |aps|
         aps['access_points'].each do |ap|
+          next unless ap['status'] == 'Up'
+
           ap_x = ap['x']
           ap_y = ap['y']
           distance = ArubaMathHelper.calculate_distance(xpos, ypos, ap_x, ap_y)


### PR DESCRIPTION
* In the `find_closest_ap` function, all access points were being considered, but only those that are turned on should be taken into account before calculating the closest one.