### PR TITLE
PR-24: The associated clients got associated with turned-off access

### DIFF
--- a/lib/api/aruba_client.rb
+++ b/lib/api/aruba_client.rb
@@ -211,6 +211,8 @@ module ArubaREST
       closest_distance = nil
       data[:aps].each do |aps|
         aps['access_points'].each do |ap|
+          next unless ap['status'] == 'Up'
+
           ap_x = ap['x']
           ap_y = ap['y']
           distance = ArubaMathHelper.calculate_distance(xpos, ypos, ap_x, ap_y)

--- a/lib/api/aruba_client.rb
+++ b/lib/api/aruba_client.rb
@@ -37,6 +37,7 @@ module ArubaREST
       @cache_ttl = cache['ttl']
       @cache_keys = cache['keys']
       @connections = {}
+      @aps = {}
       @cache = ArubaCache.new
       @log_controller = ArubaLogger::LogController.new(
         'ArubaREST',
@@ -116,6 +117,10 @@ module ArubaREST
 
         data
       end
+    end
+
+    def update_ap_status(mac_add, ap_status)
+      @aps[mac_add.downcase] = ap_status
     end
 
     def fetch_all_campuses
@@ -211,7 +216,8 @@ module ArubaREST
       closest_distance = nil
       data[:aps].each do |aps|
         aps['access_points'].each do |ap|
-          next unless ap['status'] == 'Up'
+          @log_controller.info(@aps)
+          next unless @aps[ap['ap_eth_mac'].downcase] == 'Up'
 
           ap_x = ap['x']
           ap_y = ap['y']
@@ -319,6 +325,7 @@ module ArubaREST
           ap_status: ap['status'] == 'Up' ? 'on' : 'off',
           ap_client_count: @connections[ap['macaddr']].instance_of?(NilClass) ? 0 : @connections[ap['macaddr']]
         }
+        update_ap_status(ap['macaddr'], ap['status'])
       end
       access_points
     end

--- a/lib/api/aruba_client.rb
+++ b/lib/api/aruba_client.rb
@@ -217,7 +217,7 @@ module ArubaREST
       data[:aps].each do |aps|
         aps['access_points'].each do |ap|
           next unless @aps[ap['ap_eth_mac'].downcase] == 'Up'
-          
+
           ap_x = ap['x']
           ap_y = ap['y']
           distance = ArubaMathHelper.calculate_distance(xpos, ypos, ap_x, ap_y)

--- a/lib/api/aruba_client.rb
+++ b/lib/api/aruba_client.rb
@@ -216,7 +216,6 @@ module ArubaREST
       closest_distance = nil
       data[:aps].each do |aps|
         aps['access_points'].each do |ap|
-          @log_controller.info(@aps)
           next unless @aps[ap['ap_eth_mac'].downcase] == 'Up'
 
           ap_x = ap['x']

--- a/lib/rb_arubacentral.rb
+++ b/lib/rb_arubacentral.rb
@@ -78,8 +78,8 @@ loop do
   aruba_central_sensors.each do |aruba_central_sensor|
     begin
       log_controller.info("Processing sensor #{aruba_central_sensor}")
-      location_data = generator.location_from_multiple_messages(aruba_central_sensor.fetch_location_production_data)
       status_data = generator.status_from_multiple_messages(aruba_central_sensor.fetch_ap_status_production_data)
+      location_data = generator.location_from_multiple_messages(aruba_central_sensor.fetch_location_production_data)
       producer.send_kafka_multiple_msgs(location_data, config['kafka']['location_topic'])
       producer.send_kafka_multiple_msgs(status_data, config['kafka']['status_topic'])
     rescue StandardError => e


### PR DESCRIPTION
* In the find_closest_ap function, all access points were being considered, but only those that are turned on should be taken into account before calculating the closest one.